### PR TITLE
Fixing a typo in the output from installation

### DIFF
--- a/gemcutter.gemspec
+++ b/gemcutter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem push        merged into RubyGems 1.3.6
   gem owner       merged into RubyGems 1.3.6
   gem webhook     register urls to be pinged when gems are pushed
-  gem yank        remove a specific version of a gem from RubyGemgem.org
+  gem yank        remove a specific version of a gem from RubyGems.org
 
 ********************************************************************************
 eos


### PR DESCRIPTION
s/RubyGemsgem.org/RubyGems.org
